### PR TITLE
add filer_image cmsplugin for s3 migration

### DIFF
--- a/seolondon/management/commands/migrate_url_to_s3filer_fields.py
+++ b/seolondon/management/commands/migrate_url_to_s3filer_fields.py
@@ -37,6 +37,14 @@ class Command(BaseCommand):
                 'url_field_name': 'background_image_url',
                 's3filer_field_name': 'background_image',
             },
+        'filer_image':
+            {
+                'app_label': 'cmsplugin_filer_image',
+                'model_name': 'filerimage',
+                'url_field_name': 'image_url',
+                's3filer_field_name': 'image',
+            }
+
         }
 
     def _update_model_url_s3filer(self,


### PR DESCRIPTION
since there are images stored in cmsplugin FilerImage, we add options to migrated those from cloudinary url to aws as well